### PR TITLE
Fix parse error closing brace

### DIFF
--- a/funciones.php
+++ b/funciones.php
@@ -186,8 +186,9 @@ function showLicenseError() {
         </div>
     </body>
     </html>';
-    
+
     exit();
+}
 
 // Incluir dependencias
 require_once 'config/config.php';


### PR DESCRIPTION
## Summary
- fix unclosed bracket in `funciones.php`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861feaa82f4832eb564ff7a74de3a3f